### PR TITLE
🐛 use default factory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,16 +4,3 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.1
-    hooks:
-      - id: flake8
-        name: flake8
-        args: [--config, .flake8, --max-cognitive-complexity=7]
-        additional_dependencies: [flake8-cognitive-complexity]
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        name: isort (python)
-        args: ["--profile", "black"]

--- a/src/Pyfrontier/domain/slack_weight.py
+++ b/src/Pyfrontier/domain/slack_weight.py
@@ -1,11 +1,11 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import numpy as np
 
 
 @dataclass
 class SlackWeight:
-    _weights: np.ndarray = np.array([])
+    _weights: np.ndarray = field(default_factory=[])
     _n_dim: int = 0
 
     def __post_init__(self):


### PR DESCRIPTION
Just use default_factory for Python3.11.
I encountered an issue with pre-commit, so I relaxed the settings, but I plan to address it when migrating from pipenv to ruff soon.